### PR TITLE
feat: update transition handling in DarkMode class

### DIFF
--- a/src/lib/runes.svelte.ts
+++ b/src/lib/runes.svelte.ts
@@ -1,5 +1,5 @@
 import { BROWSER as browser } from 'esm-env';
-import { CheckTransitions } from './transition.svelte.js';
+import { prefersUseViewTransitions } from './transition.svelte.js';
 import { withoutTransition } from './without-transition.js';
 
 /**
@@ -8,7 +8,6 @@ import { withoutTransition } from './without-transition.js';
 export class DarkMode {
 	_isDark = $state(true);
 	_mode: 'dark' | 'light' = $derived(this._isDark ? 'dark' : 'light');
-	ct = new CheckTransitions();
 
 	constructor() {
 		if (browser) {
@@ -43,7 +42,7 @@ export class DarkMode {
 	 * @see https://github.com/vuejs/vitepress/pull/2347
 	 */
 	toggle = (event: MouseEvent) => {
-		if (!this.ct?.isAppearanceTransition) {
+		if (!prefersUseViewTransitions.current) {
 			this._toggleMode();
 			return;
 		}

--- a/src/lib/transition.svelte.ts
+++ b/src/lib/transition.svelte.ts
@@ -4,7 +4,7 @@ import { prefersReducedMotion } from 'svelte/motion';
 /**
  * check if the browser supports appearance transition
  */
-export class CheckTransitions {
+export class CheckViewTransitions {
 	#isViewTransitionAvailable = $state(false);
 
 	constructor() {
@@ -15,7 +15,9 @@ export class CheckTransitions {
 		this.#isViewTransitionAvailable = document.startViewTransition != null;
 	}
 
-	get isAppearanceTransition() {
+	get current() {
 		return !prefersReducedMotion.current && this.#isViewTransitionAvailable;
 	}
 }
+
+export const prefersUseViewTransitions = new CheckViewTransitions();


### PR DESCRIPTION
- Replaced `CheckTransitions` with `prefersUseViewTransitions` in
  `runes.svelte.ts`
- Updated `CheckTransitions` class to `CheckViewTransitions` and
  exported an instance as `prefersUseViewTransitions` in
  `transition.svelte.ts`
- Adjusted `DarkMode` class to use `prefersUseViewTransitions.current`
  for checking view transition support
