### PR TITLE
feat: rename DarkMode to Mode

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,9 +1,9 @@
 import Header from './DarkModeHeader.svelte';
 import ToggleButton from './DarkModeToggleButton.svelte';
-import { darkMode } from './runes.svelte.js';
+import { mode } from './runes.svelte.js';
 
 export {
-	darkMode,
 	Header,
+	mode,
 	ToggleButton,
 };

--- a/src/lib/runes.svelte.ts
+++ b/src/lib/runes.svelte.ts
@@ -5,7 +5,7 @@ import { withoutTransition } from './without-transition.js';
 /**
  * Class for toggling dark mode
  */
-export class DarkMode {
+export class Mode {
 	_isDark = $state(true);
 	_mode: 'dark' | 'light' = $derived(this._isDark ? 'dark' : 'light');
 
@@ -90,21 +90,21 @@ export class DarkMode {
  * @example
  * ```svelte
  * <script>
- *   import { darkMode } from '$lib/runes.svelte';
+ *   import { mode } from '$lib/runes.svelte';
  * </script>
  *
  * <button
- *  onclick={darkMode.toggle}
+ *  onclick={mode.toggle}
  *  aria-label="Toggle Dark Mode"
  *  type="button"
  * >
  * </button>
  *
- * {#if $darkMode.current === 'dark'}
+ * {#if mode.current === 'dark'}
  *   <p>Dark Mode</p>
  * {:else}
  *   <p>Light Mode</p>
  * {/if}
  * ```
  */
-export const darkMode = new DarkMode();
+export const mode = new Mode();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,7 +27,7 @@
 	{/each}
 </div>
 
-{#if DarkMode.darkMode.current === 'dark'}
+{#if DarkMode.mode.current === 'dark'}
 	<p>Dark mode is active.</p>
 {:else}
 	<p>Dark mode is inactive.</p>


### PR DESCRIPTION
Renamed the DarkMode class to Mode and updated all references
accordingly. This change affects the following files:
- src/lib/index.ts
- src/lib/runes.svelte.ts

The new class name better reflects its functionality.
