### PR TITLE
feat!: update dark mode toggle button props

### DIFF
--- a/src/lib/DarkModeToggleButton.svelte
+++ b/src/lib/DarkModeToggleButton.svelte
@@ -6,17 +6,17 @@
 		/**
 		 * The icon to display when dark mode is active.
 		 */
-		darkIcon: Snippet;
+		dark: Snippet;
 
 		/**
 		 * The icon to display when dark mode is inactive.
 		 */
-		lightIcon: Snippet;
+		light: Snippet;
 	};
 
 	const {
-		darkIcon,
-		lightIcon,
+		dark,
+		light,
 	}: Props = $props();
 
 </script>
@@ -28,8 +28,8 @@
 >
 
 	{#if mode.current === 'dark'}
-		{@render darkIcon()}
+		{@render dark()}
 	{:else}
-		{@render lightIcon()}
+		{@render light()}
 	{/if}
 </button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,11 +16,11 @@
 		<!-- darkmode toggle button -->
 		<!-- set icons or text for the button with snippets -->
 		<DarkMode.ToggleButton>
-			{#snippet darkIcon()}
+			{#snippet dark()}
 				<SunnyToMoon />
 			{/snippet}
 
-			{#snippet lightIcon()}
+			{#snippet light()}
 				<MoonToSunny />
 			{/snippet}
 		</DarkMode.ToggleButton>


### PR DESCRIPTION
- Renamed `darkIcon` to `dark` in DarkModeToggleButton.svelte
- Renamed `lightIcon` to `light` in DarkModeToggleButton.svelte
- Updated references to the renamed props in +page.svelte
